### PR TITLE
Use Concrete Version for `@alicloud/tea-typescript` Dependency

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -29,7 +29,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@alicloud/tea-typescript": "latest"
+    "@alicloud/tea-typescript": "^1.7.1"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This PR changes the version of the `@alicloud/tea-typescript` dependency to ´^1.7.1` (as it is done in all other @alicloud libraries, see https://github.com/search?q=repo%3Aaliyun%2Falibabacloud-typescript-sdk%20%40alicloud%2Ftea-typescript&type=code).

Having the version set to `latest` can create problems in air-gapped systems, as evaluating the `latest` tag seem to require a connection to `npmjs.org` and download the necessary metadata (even if you bundle all your dependecies). In contrast, if you bundle your dependency (provide `node_modules` and a `package-lock.json`) you can avoid this if the concrete versions are pinned.